### PR TITLE
docs: fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
 
                 <div class="col-1-of-2">
                     <p class="footer__copyright">
-                        Built by &nbsp;&nbsp;<a href="https://github.com/jayli3n" class="footer__link footer__link--2" target="_blank">Jay Li</a>&nbsp;&nbsp; for practice only. View sourse code on my &nbsp;&nbsp;<a href="https://github.com/jayli3n/natours-startup" class="footer__link footer__link--2" target="_blank">GitHub</a>&nbsp;&nbsp; page.
+                        Built by &nbsp;&nbsp;<a href="https://github.com/jayli3n" class="footer__link footer__link--2" target="_blank">Jay Li</a>&nbsp;&nbsp; for practice only. View source code on my &nbsp;&nbsp;<a href="https://github.com/jayli3n/natours-startup" class="footer__link footer__link--2" target="_blank">GitHub</a>&nbsp;&nbsp; page.
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Fixes typo from `sourse` to `source`